### PR TITLE
preserve '$(' literal rendering from Genshi

### DIFF
--- a/kajiki/xml_template.py
+++ b/kajiki/xml_template.py
@@ -332,7 +332,7 @@ class _TextCompiler(object):
 
     _pattern = r'''
     \$(?:
-        (?P<expr_escaped>\$) |      # Escape $$
+        (?P<expr_escaped>\$|(?=\()) |      # Escape $$, $(
         (?P<expr_named>[_a-z][_a-z0-9.]*) | # $foo.bar
         {(?P<expr_braced>) | # ${....
         (?P<expr_invalid>)


### PR DESCRIPTION
Preserve Genshi's handling of '$(' as a text literal, since it cannot be a
valid variable sequence.  This simplifies, for example, templates
containing inline scripts with jQuery calls which otherwise have to be
written '$$(...'

Example template:

```
<!DOCTYPE html>
<html>
<head>
    <title></title>
</head>
<body>
    <p>Test: $(</p>
</body>
</html>
```

Genshi renders the paragraph "Test: $(" while Kajiki throws an error.
