### PR TITLE
Try to get smarter CDATA parsing

### DIFF
--- a/kajiki/loader.py
+++ b/kajiki/loader.py
@@ -42,7 +42,7 @@ class MockLoader(Loader):
 
 class FileLoader(Loader):
     def __init__(self, path, reload=True, force_mode=None,
-                 autoescape_text=False):
+                 autoescape_text=False, xml_autoblocks=None):
         super(FileLoader, self).__init__()
         from kajiki import XMLTemplate, TextTemplate
         if isinstance(path, basestring):
@@ -53,6 +53,7 @@ class FileLoader(Loader):
         self._reload = reload
         self._force_mode = force_mode
         self._autoescape_text = autoescape_text
+        self._xml_autoblocks = xml_autoblocks
         self.extension_map = dict(
             txt=lambda *a, **kw: TextTemplate(
                 autoescape=self._autoescape_text, *a, **kw),
@@ -88,7 +89,9 @@ class FileLoader(Loader):
                 autoescape=self._autoescape_text, *args, **kwargs)
         elif self._force_mode:
             return XMLTemplate(filename=filename,
-                mode=self._force_mode, *args, **kwargs)
+                               mode=self._force_mode,
+                               autoblocks=self._xml_autoblocks,
+                               *args, **kwargs)
         else:
             ext = os.path.splitext(filename)[1][1:]
             return self.extension_map[ext](

--- a/kajiki/tests/test_xml.py
+++ b/kajiki/tests/test_xml.py
@@ -71,7 +71,7 @@ def perform(source, expected_output, context=dict(name='Rick'),
     try:
         rsp = tpl(context).render()
         assert isinstance(rsp, str), 'render() must return a unicode string.'
-        assert rsp == expected_output, rsp
+        assert rsp == expected_output, (rsp, expected_output)
     except:
         print('\n' + tpl.py_text)
         raise
@@ -126,6 +126,24 @@ class TestSimple(TestCase):
         src = '<script><![CDATA[ $name ]]></script>'
         perform(src, '<script>/*<![CDATA[*/ Rick /*]]>*/</script>', mode='xml')
         perform(src, '<script> Rick </script>', mode='html')
+
+    def test_CDATA_escaping(self):
+        src = u'''<myxml><data><![CDATA[&gt;&#240; $name]]></data></myxml>'''
+        perform(src, '<myxml><data><![CDATA[&gt;&#240; Rick]]></data></myxml>', mode='xml')
+        perform(src, '<myxml><data><![CDATA[&gt;&#240; Rick]]></data></myxml>', mode='html')
+
+    def test_CDATA_escaping_mixed(self):
+        src = u'''<myxml><data><![CDATA[&gt;&#240; $name]]> &gt;</data></myxml>'''
+        perform(src, '<myxml><data><![CDATA[&gt;&#240; Rick]]> &gt;</data></myxml>', mode='xml')
+        perform(src, '<myxml><data><![CDATA[&gt;&#240; Rick]]> &gt;</data></myxml>', mode='html')
+
+    def test_script_commented_CDATA(self):
+        script = 'if (1 < 2) { doc.write("<p>Offen&nbsp;bach</p>"); }\n'
+        src = '<script>/*<![CDATA[*/\n{0}/*]]>*/</script>'.format(script)
+        perform(src, mode='html',
+                expected_output='<script>/**/\n{0}/**/</script>'.format(script))
+        perform(src, '<script>/*<![CDATA[*//**/\n{0}/**//*]]>*/</script>'.format(
+                script), mode='xml')
 
     def test_escape_dollar(self):
         perform('<div>$$</div>', '<div>$</div>')

--- a/kajiki/tests/test_xml.py
+++ b/kajiki/tests/test_xml.py
@@ -128,12 +128,12 @@ class TestSimple(TestCase):
         perform(src, '<script> Rick </script>', mode='html')
 
     def test_CDATA_escaping(self):
-        src = u'''<myxml><data><![CDATA[&gt;&#240; $name]]></data></myxml>'''
+        src = '''<myxml><data><![CDATA[&gt;&#240; $name]]></data></myxml>'''
         perform(src, '<myxml><data><![CDATA[&gt;&#240; Rick]]></data></myxml>', mode='xml')
         perform(src, '<myxml><data><![CDATA[&gt;&#240; Rick]]></data></myxml>', mode='html')
 
     def test_CDATA_escaping_mixed(self):
-        src = u'''<myxml><data><![CDATA[&gt;&#240; $name]]> &gt;</data></myxml>'''
+        src = '''<myxml><data><![CDATA[&gt;&#240; $name]]> &gt;</data></myxml>'''
         perform(src, '<myxml><data><![CDATA[&gt;&#240; Rick]]> &gt;</data></myxml>', mode='xml')
         perform(src, '<myxml><data><![CDATA[&gt;&#240; Rick]]> &gt;</data></myxml>', mode='html')
 

--- a/kajiki/tests/test_xml.py
+++ b/kajiki/tests/test_xml.py
@@ -66,8 +66,9 @@ class TestExpand(TestCase):
 
 
 def perform(source, expected_output, context=dict(name='Rick'),
-            mode='xml', is_fragment=True):
-    tpl = XMLTemplate(source, mode=mode, is_fragment=is_fragment)
+            mode='xml', is_fragment=True, cdata_scripts=True):
+    tpl = XMLTemplate(source, mode=mode, is_fragment=is_fragment,
+                      cdata_scripts=cdata_scripts)
     try:
         rsp = tpl(context).render()
         assert isinstance(rsp, str), 'render() must return a unicode string.'
@@ -126,6 +127,11 @@ class TestSimple(TestCase):
         src = '<script><![CDATA[ $name ]]></script>'
         perform(src, '<script>/*<![CDATA[*/ Rick /*]]>*/</script>', mode='xml')
         perform(src, '<script> Rick </script>', mode='html')
+
+    def test_CDATA_disabled(self):
+        src = '<script> $name </script>'
+        perform(src, '<script> Rick </script>', mode='xml', cdata_scripts=False)
+        perform(src, '<script> Rick </script>', mode='html', cdata_scripts=False)
 
     def test_CDATA_escaping(self):
         src = '''<myxml><data><![CDATA[&gt;&#240; $name]]></data></myxml>'''


### PR DESCRIPTION
Trying to tackle https://github.com/nandoflorestan/kajiki/issues/6

The three new tests have been created by seeing the result of ``genshi.template.MarkupTemplate`` in the same situation and trying to replicate the behaviour.

The automatic ``CDATA`` for ``script`` and ``style`` has been left in place, I suppose it would be a far easier to maintain behaviour to force users to provide CDATA themselves in script and style as Genshi does, the current automatic behaviour works both when user specifies CDATA and when it doesn't, but it's far more complex for a minimum benefit.