### PR TITLE
Autoblocks

### DIFF
--- a/kajiki/loader.py
+++ b/kajiki/loader.py
@@ -42,7 +42,7 @@ class MockLoader(Loader):
 
 class FileLoader(Loader):
     def __init__(self, path, reload=True, force_mode=None,
-                 autoescape_text=False):
+                 autoescape_text=False, xml_autoblocks=None):
         super(FileLoader, self).__init__()
         from kajiki import XMLTemplate, TextTemplate
         if isinstance(path, basestring):
@@ -53,6 +53,7 @@ class FileLoader(Loader):
         self._reload = reload
         self._force_mode = force_mode
         self._autoescape_text = autoescape_text
+        self._xml_autoblocks = xml_autoblocks
         self.extension_map = dict(
             txt=lambda *a, **kw: TextTemplate(
                 autoescape=self._autoescape_text, *a, **kw),
@@ -88,7 +89,9 @@ class FileLoader(Loader):
                 autoescape=self._autoescape_text, *args, **kwargs)
         elif self._force_mode:
             return XMLTemplate(filename=filename,
-                mode=self._force_mode, *args, **kwargs)
+                               mode=self._force_mode,
+                               autoblocks=self._xml_autoblocks,
+                               *args, **kwargs)
         else:
             ext = os.path.splitext(filename)[1][1:]
             return self.extension_map[ext](

--- a/kajiki/tests/test_xml.py
+++ b/kajiki/tests/test_xml.py
@@ -430,6 +430,82 @@ Thanks for the gift!</p>
 Sincerely,<br/><em>Rick</em>
 </div>''', rsp
 
+    def test_autoblocks(self):
+        loader = MockLoader({
+            'parent.html': XMLTemplate('''
+<html py:strip="">
+<head></head>
+<body>
+    <p py:block="body">It was good seeing you last Friday.
+    Thanks for the gift!</p>
+</body>
+</html>'''),
+            'child.html': XMLTemplate('''
+<html>
+<py:extends href="parent.html"/>
+<body><em>Great conference this weekend!</em></body>
+</html>''', autoblocks=['body'])})
+
+        parent = loader.import_('parent.html')
+        rsp = parent().render()
+        assert rsp == '''
+<head/>
+<body>
+    <p>It was good seeing you last Friday.
+    Thanks for the gift!</p>
+</body>
+''', rsp
+
+        child = loader.import_('child.html')
+        rsp = child().render()
+        assert rsp == '''<html>
+
+<head/>
+<body>
+    <em>Great conference this weekend!</em>
+</body>
+
+
+</html>''', rsp
+
+    def test_autoblocks_disabling(self):
+        loader = MockLoader({
+            'parent.html': XMLTemplate('''
+<html py:strip="">
+<head></head>
+<body py:autoblock="False">
+    <p py:block="body">It was good seeing you last Friday.
+    Thanks for the gift!</p>
+</body>
+</html>''', autoblocks=['body']),
+            'child.html': XMLTemplate('''
+<html>
+<py:extends href="parent.html"/>
+<body><em>Great conference this weekend!</em></body>
+</html>''', autoblocks=['body'])})
+
+        parent = loader.import_('parent.html')
+        rsp = parent().render()
+        assert rsp == '''
+<head/>
+<body>
+    <p>It was good seeing you last Friday.
+    Thanks for the gift!</p>
+</body>
+''', rsp
+
+        child = loader.import_('child.html')
+        rsp = child().render()
+        assert rsp == '''<html>
+
+<head/>
+<body>
+    <em>Great conference this weekend!</em>
+</body>
+
+
+</html>''', rsp
+
 
 class TestClosure(TestCase):
     def test(self):


### PR DESCRIPTION
Autoblocks provide a quick way to convert Genshi templates to Kajiki by automatically declare blocks for body and head without having to touch all the templates of the application.

See http://turbogears.readthedocs.org/en/development/turbogears/genshi-xml-templates.html#converting-genshi-templates-to-kajiki for details about the idea behind this proposed patch.

I'm currently experimenting with moving TurboGears to Kajiki to cope with Genshi lacking support for Python3.4 and 3.5 and seeming unwilling to get supported anymore.