### PR TITLE
README: Declare example is sourcecode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,8 @@ And more features are coming soon; stay tuned!
 Example
 =======
 
+.. code:: python
+
     >>> import kajiki
     >>> Template = kajiki.XMLTemplate('''<html>
     ...     <head><title>$title</title></head>


### PR DESCRIPTION
This syntax highlights it on Github, and should do the same on PyPI.