### PR TITLE
Refactor py:with to improve multiple variable handling

### DIFF
--- a/kajiki/template.py
+++ b/kajiki/template.py
@@ -80,10 +80,8 @@ class _Template(object):
     def render(self):
         return ''.join(self)
 
-    def _push_with(self, lcls, **kw):
-        d = dict((k, lcls.get(k, ()))
-                 for k in kw)
-        self._with_stack.append(d)
+    def _push_with(self, locals_, vars):
+        self._with_stack.append([locals_.get(k, ()) for k in vars])
 
     def _pop_with(self):
         return self._with_stack.pop()

--- a/kajiki/tests/test_xml.py
+++ b/kajiki/tests/test_xml.py
@@ -243,6 +243,23 @@ class TestWith(TestCase):
 <div>foo - 3</div>
 </div>''')
 
+    def test_with_multiple_and_whitespace(self):
+        perform('''<div py:with="a = 'foo';
+                                 b = 3">$a - $b</div>''',
+                '<div>foo - 3</div>')
+
+    def test_with_trailing_semicolon(self):
+        perform('''<div py:with="a = 'foo';">$a</div>''',
+                '<div>foo</div>')
+
+    def test_with_ordered_multiple(self):
+        perform('''<div py:with="a='foo';b=a * 2;c=b[::-1];d=c[:3]">'''
+                '''$a $b $c $d</div>''',
+                '<div>foo foofoo oofoof oof</div>')
+
+    def test_with_multiple_with_embedded_semicolons(self):
+        perform('''<div py:with="a=';';b='-)'">$a$b</div>''',
+                '<div>;-)</div>')
 
 
 class TestFunction(TestCase):

--- a/kajiki/util.py
+++ b/kajiki/util.py
@@ -2,6 +2,7 @@
 
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+from collections import deque
 import sys
 from random import randint
 from threading import local
@@ -108,3 +109,13 @@ class NameGen(object):
 
 def gen_name(hint='_kj_'):
     return NameGen.gen(hint)
+
+
+def window(seq, n=2):
+    """Return a sliding window of size ``n`` over an iterator"""
+    l = deque((next(seq, None) for _ in range(n)), maxlen=n)
+    push = l.append
+    yield l
+    for item in seq:
+        push(item)
+        yield l


### PR DESCRIPTION
- Whitespace may be included after the semicolon separator in multiple assignments
- The parser is more forgiving of assignments containing a semicolon on the
  right hand side
- Trailing semicolons no longer cause errors
- The order of assignments is maintained so that later assignments may
  reference earlier ones (eg py:with="a = 2; b = a + 3").