### PR TITLE
Support multi-line ${} expressions

### DIFF
--- a/kajiki/tests/test_text.py
+++ b/kajiki/tests/test_text.py
@@ -52,6 +52,12 @@ class TestBasic(TestCase):
         rsp = tpl(dict(obj=Empty)).render()
         assert rsp == 'Hello, Rick\n', rsp
 
+    def test_expr_multiline(self):
+        tpl = TextTemplate(source="""Hello, ${{'name': 'Rick',
+                                               'age': 26}['name']}""")
+        rsp = tpl().render()
+        assert rsp == 'Hello, Rick', (rsp, 'Hello, Rick')
+
 
 class TestSwitch(TestCase):
     def test_switch(self):

--- a/kajiki/tests/test_xml.py
+++ b/kajiki/tests/test_xml.py
@@ -174,6 +174,16 @@ class TestSimple(TestCase):
         perform("<div>Hello, ${{'name':name}['name']}</div>",
                 '<div>Hello, Rick</div>')
 
+    def test_expr_multiline(self):
+        perform("""<div>Hello, ${{'name': 'Rick',
+                                 'age': 26}['name']}</div>""",
+                '<div>Hello, Rick</div>')
+
+    def test_expr_multiline_cdata(self):
+        perform("""<script><![CDATA[Hello, ${{'name': 'Rick',
+                                 'age': 26}['name']}]]></script>""",
+                '<script>/*<![CDATA[*/Hello, Rick/*]]>*/</script>')
+
     def test_jquery_call_is_not_expr(self):
         '''Ensure we handle '$(' as a text literal, since it cannot be a
         valid variable sequence.  This simplifies, for example,

--- a/kajiki/text.py
+++ b/kajiki/text.py
@@ -156,7 +156,9 @@ class _Scanner(object):
         try:
             compile(self.source[self.pos:], '', 'eval')
         except SyntaxError as se:
-            end = se.offset + self.pos
+            end = self.pos + sum([se.offset] + [len(line) + 1
+                                                for idx, line in enumerate(self.source[self.pos:].splitlines())
+                                                if idx < se.lineno - 1])
             text = self.source[self.pos:end - 1]
             self.pos = end
             return self.expr(text)

--- a/kajiki/xml_template.py
+++ b/kajiki/xml_template.py
@@ -143,27 +143,27 @@ class _Compiler(object):
     def _merge_text_nodes(self, nodes):
         """Merges consecutive TextNodes into a single TextNode by adding together
         the TextNode's data. Any other node (including CDATA TextNodes) splits
-        runs of TextNodes.
+        runs of TextNodes. Returns a list of Nodes.
         """
-        idx = 0
         merge_node = None
-        while idx < len(nodes):
-            if getattr(nodes[idx], '_cdata', False):
+        merged_nodes = []
+        for node in nodes:
+            if getattr(node, '_cdata', False):
                 merge_node = None
-                idx = idx + 1
+                merged_nodes.append(node)
             else:
-                if isinstance(nodes[idx], dom.Text):
+                if isinstance(node, dom.Text):
                     if merge_node is None:
-                        merge_node = nodes[idx]
-                        idx = idx + 1
+                        merge_node = node.ownerDocument.createTextNode(node.data)
+                        merge_node.lineno = node.lineno
+                        merge_node.escaped = node.escaped
+                        merged_nodes.append(merge_node)
                     else:
-                        merge_node.data = merge_node.data + nodes[idx].data
-                        nodes = nodes[0:idx] + nodes[idx + 1:]
+                        merge_node.data = merge_node.data + node.data
                 else:
                     merge_node = None
-                    idx = idx + 1
-        return nodes
-
+                    merged_nodes.append(node)
+        return merged_nodes
 
     @annotate
     def _compile_xml(self, node):


### PR DESCRIPTION
I've now implemented a cleaner version of the code for supporting multi-line ${} expressions in both the XML and Text templates. In the Text templates, all that needed to be done was to update the "end of expression" calculation to take into account new-lines. In the XML templates the code first merges consecutive runs of TextNodes into a single TextNode. That way the expression regexp can then find the full multi-line expression. It does this by creating a new TextNode to merge the content into. It knows about CDATA blocks.

Additional test cases are included and all tests pass.