### PR TITLE
Allow function calls in attributes

### DIFF
--- a/kajiki/template.py
+++ b/kajiki/template.py
@@ -198,7 +198,10 @@ class _Template(object):
         for part in it:
             if part is None:
                 continue
-            result.append(str(part))
+            if isinstance(part, flattener):
+                result.append(str(part.accumulate_str()))
+            else:
+                result.append(str(part))
         if result:
             return ''.join(result)
         else:

--- a/kajiki/tests/test_xml.py
+++ b/kajiki/tests/test_xml.py
@@ -363,6 +363,13 @@ class TestFunction(TestCase):
         perform('<div><py:def function="bruhaha()"></py:def></div>',
                 '<div></div>')
 
+    def test_function_in_attr(self):
+        '''Attribute value with a function call.'''
+        perform('''<div
+><py:def function="attrtest(n, sz=16)">text/$sz/$n</py:def><img
+src="${attrtest(name)}"/></div>''',
+                '<div><img src="text/16/Rick"/></div>')
+
 
 class TestCall(TestCase):
     def test_call(self):

--- a/kajiki/util.py
+++ b/kajiki/util.py
@@ -61,7 +61,7 @@ class flattener(object):
         iter_stack = [self.iterator]
         while iter_stack:
             try:
-                x = iter_stack[-1].next()
+                x = next(iter_stack[-1])
             except StopIteration:
                 iter_stack.pop()
                 continue


### PR DESCRIPTION
Render function result into atrribute value, instead of
storing `<kajiki.util.flattener object...>`
This closes #25 and adds a simple test.