### PR TITLE
docs: Fix simple typo, extracing -> extracting

### DIFF
--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -3,7 +3,7 @@ Internationalization
 ====================
 
 Kajiki provides supporting infrastructure for internationalizing and localizing
-templates.  This includes functionality for extracing localizable strings from
+templates.  This includes functionality for extracting localizable strings from
 templates, as well as translation of localizable strings.
 
 Basics
@@ -34,7 +34,7 @@ module::
 Extraction
 =====================
 
-Kajiki also provides support for extracing all localizable strings found in a
+Kajiki also provides support for extracting all localizable strings found in a
 template.  This functionality is integrated with the excellent message extraction
 framework provided by the Babel_ project.  Typically, you would notify Babel of
 the location of your templates before running the extraction routine:


### PR DESCRIPTION
There is a small typo in docs/i18n.rst.

Should read `extracting` rather than `extracing`.

