### PR TITLE
Add a command line interface

### DIFF
--- a/kajiki/__main__.py
+++ b/kajiki/__main__.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""Command-line interface to Kajiki to render a single template."""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import argparse
+import os
+import site
+import sys
+
+import kajiki.loader
+
+
+def _kv_pair(pair):
+    """Convert a KEY=VALUE string to a 2-tuple of (KEY, VALUE).
+
+    This is intended for usage with the type= argument to argparse.
+    """
+    key, sep, value = pair.partition('=')
+    if not sep:
+        raise argparse.ArgumentTypeError(
+            'Expected a KEY=VALUE pair, got {}'.format(pair))
+    return key, value
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '-m', '--mode',
+        dest='force_mode',
+        choices=['text', 'xml', 'html', 'html5'],
+        help=('Force a specific templating mode instead of auto-detecting '
+              'based on extension.'),
+    )
+    parser.add_argument(
+        '-i', '--path',
+        action='append',
+        dest='paths',
+        default=[],
+        metavar='path',
+        help=("Add to the file loader's include paths.  For the package "
+              "loader, this will add the path to Python's site directories."),
+    )
+    parser.add_argument(
+        '-v', '--var',
+        action='append',
+        dest='template_variables',
+        default=[],
+        type=_kv_pair,
+        metavar='KEY=VALUE',
+        help='Template variables, passed as KEY=VALUE pairs.',
+    )
+    parser.add_argument(
+        '-p', '--package',
+        dest='loader_type',
+        action='store_const',
+        const=kajiki.loader.PackageLoader,
+        default=kajiki.loader.FileLoader,
+        help='Load based on package name instead of file path.',
+    )
+    parser.add_argument(
+        'file_or_package',
+        help='Filename or package to load.',
+    )
+    parser.add_argument(
+        'output_file',
+        type=argparse.FileType('w'),
+        default=sys.stdout,
+        nargs='?',
+        help='Output file.  If unspecified, use stdout.',
+    )
+
+    opts = parser.parse_args(argv)
+
+    loader_kwargs = {}
+    if opts.loader_type is kajiki.loader.PackageLoader:
+        for path in opts.paths:
+            site.addsitedir(path)
+    else:
+        opts.paths.append(os.path.dirname(opts.file_or_package) or '.')
+        loader_kwargs['path'] = opts.paths
+
+    loader = opts.loader_type(
+        force_mode=opts.force_mode,
+        **loader_kwargs)
+    template = loader.import_(opts.file_or_package)
+    result = template(dict(opts.template_variables)).render()
+    opts.output_file.write(result)
+
+    # Close the output file to avoid a ResourceWarning during unit
+    # tests on Python 3.4+.  But don't close stdout, just flush it
+    # instead.
+    if opts.output_file is sys.stdout:
+        opts.output_file.flush()
+    else:
+        opts.output_file.close()
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])  # pragma: no cover

--- a/kajiki/tests/test_cli.py
+++ b/kajiki/tests/test_cli.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import io
+import unittest
+import site
+import sys
+import os
+
+if sys.version_info[:2] < (3, 2):
+    import backports.tempfile as tempfile
+else:
+    import tempfile
+
+if sys.version_info[:2] < (3, 3):
+    # Third-party before Python 3.3
+    import mock
+else:
+    import unittest.mock as mock
+
+import kajiki.loader
+from kajiki.__main__ import main
+
+
+XHTML1 = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" ' \
+         '"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'
+
+
+class TestCLI(unittest.TestCase):
+    def setattr_reset(self, obj, attr, value):
+        # Like setattr, but reset to the original value during
+        # tearDown.
+        orig = getattr(obj, attr)
+        setattr(obj, attr, value)
+        self.reset_list.append((obj, attr, orig))
+
+    def tearDown(self):
+        while self.reset_list:
+            obj, attr, orig = self.reset_list.pop()
+            setattr(obj, attr, orig)
+
+    def setUp(self):
+        # Create the reset list if not already existing.
+        self.reset_list = getattr(self, 'reset_list', [])
+
+        self.mocked_addsitedir = mock.Mock()
+        self.setattr_reset(site, 'addsitedir', self.mocked_addsitedir)
+
+        mocked_render = mock.Mock(return_value='render result')
+        self.mocked_render = mocked_render
+
+        class MockedTemplate(object):
+            def render(self, *args, **kwargs):
+                return mocked_render(*args, **kwargs)
+
+        self.mocked_template_type = mock.Mock(return_value=MockedTemplate())
+
+        mocked_import = mock.Mock(return_value=self.mocked_template_type)
+        self.mocked_import = mocked_import
+
+        class MockedLoader(object):
+            def import_(self, *args, **kwargs):
+                return mocked_import(*args, **kwargs)
+
+        self.mocked_file_loader_type = mock.Mock(return_value=MockedLoader())
+        self.setattr_reset(kajiki.loader, 'FileLoader',
+                           self.mocked_file_loader_type)
+
+        self.mocked_package_loader_type = mock.Mock(
+            return_value=MockedLoader())
+        self.setattr_reset(kajiki.loader, 'PackageLoader',
+                           self.mocked_package_loader_type)
+
+        self.mocked_stdout = io.StringIO()
+        self.setattr_reset(sys, 'stdout', self.mocked_stdout)
+
+    def test_simple_file_load(self):
+        for filename, load_path in [
+                ('filename.txt', '.'),
+                ('/path/to/filename.xml', '/path/to'),
+                ('some/subdir/myfile.html', 'some/subdir'),
+        ]:
+            main([filename])
+
+            self.mocked_file_loader_type.assert_called_once_with(
+                path=[load_path], force_mode=None)
+            self.mocked_import.assert_called_once_with(filename)
+            self.mocked_template_type.assert_called_once_with({})
+            self.mocked_render.assert_called_once_with()
+            assert self.mocked_stdout.getvalue() == 'render result'
+
+            # Reset mocks for next set of params.
+            self.setUp()
+
+    def test_simple_package_load(self):
+        main(['-p', 'my.cool.package'])
+
+        self.mocked_package_loader_type.assert_called_once_with(
+            force_mode=None)
+        self.mocked_import.assert_called_once_with('my.cool.package')
+        self.mocked_template_type.assert_called_once_with({})
+        self.mocked_render.assert_called_once_with()
+        assert self.mocked_stdout.getvalue() == 'render result'
+
+    def test_package_loader_site_dirs(self):
+        main(['-i', '/usr/share/my-python-site',
+              '-i', 'relative/site/path',
+              '-i', 'another',
+              '-p', 'my.cool.package'])
+
+        self.mocked_addsitedir.assert_has_calls(
+            [
+                mock.call('/usr/share/my-python-site'),
+                mock.call('relative/site/path'),
+                mock.call('another'),
+            ])
+
+        self.mocked_package_loader_type.assert_called_once_with(
+            force_mode=None)
+        self.mocked_import.assert_called_once_with('my.cool.package')
+        self.mocked_template_type.assert_called_once_with({})
+        self.mocked_render.assert_called_once_with()
+        assert self.mocked_stdout.getvalue() == 'render result'
+
+    def test_output_to_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            outfile = os.path.join(d, 'output_file.txt')
+            main(['infile.txt', outfile])
+
+            self.mocked_file_loader_type.assert_called_once_with(
+                path=['.'], force_mode=None)
+            self.mocked_import.assert_called_once_with('infile.txt')
+            self.mocked_template_type.assert_called_once_with({})
+            self.mocked_render.assert_called_once_with()
+
+            with open(outfile, 'r') as f:
+                assert f.read() == 'render result'
+
+    def test_template_variables(self):
+        main(['-v', 'foo=bar',
+              '-v', 'baz=bip',
+              'infile.txt'])
+
+        self.mocked_file_loader_type.assert_called_once_with(
+            path=['.'], force_mode=None)
+        self.mocked_import.assert_called_once_with('infile.txt')
+        self.mocked_template_type.assert_called_once_with({
+            'foo': 'bar',
+            'baz': 'bip',
+        })
+        self.mocked_render.assert_called_once_with()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,10 @@ py_version = sys.version_info[:2]
 TEST_DEPENDENCIES = ['babel', 'nose']
 if py_version == (2, 6):
     TEST_DEPENDENCIES.extend(['importlib'])
+if py_version < (3, 2):
+    TEST_DEPENDENCIES.extend(['backports.tempfile'])
+if py_version < (3, 3):
+    TEST_DEPENDENCIES.extend(['mock'])
 
 
 setup(name='Kajiki',
@@ -75,6 +79,9 @@ setup(name='Kajiki',
       },
       test_suite='nose.collector',
       entry_points="""
+          [console_scripts]
+          kajiki = kajiki.__main__:main
+
           [babel.extractors]
           kajiki = kajiki.i18n:extract
 


### PR DESCRIPTION
This adds a command line entry point similar to the one discussed in
Issue #32.  This provides users the convenience to test and use
templates outside of Python code with ease.

(Yes, I did open this issue 4 years ago and only got around to it
now... better late than never haha.)

The CLI has good test coverage, so it should help prevent breakages
going into the future.

FIXES=#32